### PR TITLE
Add basic Textual TUI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ Keine Benutzerverwaltung
 Keine komplexen Reportings
 
 Kein Netzwerkzugriff
+
+
+## TUI
+
+Für eine komfortablere Bedienung steht eine textbasierte Oberfläche zur Verfügung.
+Sie benötigt die Bibliothek `textual`, die über `pip install textual` installiert wird.
+Gestartet wird die Oberfläche mit:
+
+```bash
+python main.py tui
+```
+
+Navigiert wird mit den Pfeiltasten. `Tab` wechselt zwischen Menü und Artikelliste,
+`Enter` führt die Auswahl aus und `q` beendet die Anwendung.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import argparse
 from database.db import init_db, export_db, import_db
 from modules import inventory
+import tui
 
 VERSION = "0.1"
 
@@ -35,6 +36,11 @@ def import_command(args):
     print(f"Datenbank aus {args.file} importiert")
 
 
+def tui_command(_):
+    init_db()
+    tui.main()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="CLI Warenwirtschaftssystem")
     parser.add_argument("--version", action="version", version=VERSION)
@@ -63,9 +69,13 @@ def main() -> None:
     import_parser.add_argument("--file", required=True, help="Quelldatei")
     import_parser.set_defaults(func=import_command)
 
+    tui_parser = subparsers.add_parser("tui", help="Textoberfläche starten")
+    tui_parser.set_defaults(command="tui", func=tui_command)
+
     args = parser.parse_args()
     if hasattr(args, "func"):
-        init_db()
+        if args.command != "tui":
+            init_db()
         args.func(args)
     else:
         parser.print_help()

--- a/modules/inventory.py
+++ b/modules/inventory.py
@@ -112,3 +112,67 @@ def remove_item(item_id: str) -> None:
     else:
         print("Abgebrochen.")
     conn.close()
+
+
+# Backend-Funktionen für die TUI
+
+def list_items() -> list:
+    """Gibt alle Artikel als Liste von Zeilen zurück."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM items ORDER BY id")
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def get_item(item_id: str) -> Optional[dict]:
+    """Liefert einen Artikel als Dictionary oder ``None``."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM items WHERE id=?", (item_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def add_item(data: dict) -> None:
+    """Fügt einen neuen Artikel mit den übergebenen Daten hinzu."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO items (id, name, kategorie, anzahl, status, eingesetzt, notiz) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            data["id"],
+            data["name"],
+            data["kategorie"],
+            int(data["anzahl"]),
+            data["status"],
+            data.get("eingesetzt"),
+            data.get("notiz"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def update_item_fields(item_id: str, data: dict) -> None:
+    """Aktualisiert die angegebenen Felder eines Artikels."""
+    if not data:
+        return
+    conn = get_connection()
+    cur = conn.cursor()
+    fields = ", ".join(f"{k}=?" for k in data.keys())
+    values = list(data.values()) + [item_id]
+    cur.execute(f"UPDATE items SET {fields} WHERE id=?", values)
+    conn.commit()
+    conn.close()
+
+
+def remove_item_by_id(item_id: str) -> None:
+    """Löscht einen Artikel anhand seiner ID."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM items WHERE id=?", (item_id,))
+    conn.commit()
+    conn.close()

--- a/tui.py
+++ b/tui.py
@@ -1,0 +1,148 @@
+from textual.app import App, ComposeResult
+from textual.widgets import ListView, ListItem, Label, Static, DataTable, Input, Button
+from textual.screen import ModalScreen
+from modules import inventory
+
+
+class ItemForm(ModalScreen):
+    """Eingabedialog für Artikel."""
+
+    def __init__(self, item: dict | None = None):
+        super().__init__()
+        self.item = item or {}
+
+    def compose(self) -> ComposeResult:
+        yield Static("Artikel", classes="title")
+        yield Input(value=self.item.get("id", inventory.propose_id()), placeholder="ID", id="id")
+        yield Input(value=self.item.get("name", ""), placeholder="Name", id="name")
+        yield Input(value=self.item.get("kategorie", ""), placeholder="Kategorie", id="kategorie")
+        yield Input(value=str(self.item.get("anzahl", "")), placeholder="Anzahl", id="anzahl")
+        yield Input(value=self.item.get("status", ""), placeholder="Status", id="status")
+        yield Input(value=self.item.get("eingesetzt", "") or "", placeholder="Eingesetzt", id="eingesetzt")
+        yield Input(value=self.item.get("notiz", "") or "", placeholder="Notiz", id="notiz")
+        yield Button("Speichern", id="save")
+        yield Button("Abbrechen", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "save":
+            data = {widget.id: widget.value for widget in self.query(Input)}
+            data["anzahl"] = int(data.get("anzahl") or 0)
+            self.dismiss(data)
+        else:
+            self.dismiss(None)
+
+
+class InventoryApp(App):
+    """Einfache TUI für das Inventar."""
+
+    CSS = """
+    Screen { layout: grid; grid-size: 2 2; grid-rows: 1fr 6; grid-columns: 25 1fr; }
+    #menu { grid-row: 1; grid-column: 1; }
+    #detail { grid-row: 1; grid-column: 2; }
+    #table { grid-row: 2; grid-column: 1 / span 2; height: 8; }
+    #status { dock: bottom; height: 1; }
+    """
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("tab", "switch_focus", "Switch"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        menu = ListView(
+            ListItem(Label("Add")),
+            ListItem(Label("Update")),
+            ListItem(Label("Remove")),
+            ListItem(Label("Show")),
+            ListItem(Label("Quit")),
+            id="menu",
+        )
+        detail = Static("", id="detail")
+        table = DataTable(id="table")
+        status = Static("", id="status")
+        yield menu
+        yield detail
+        yield table
+        yield status
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.add_columns("ID", "Name", "Status")
+        self.refresh_table()
+        self.set_focus(self.query_one(ListView))
+
+    def refresh_table(self) -> None:
+        table = self.query_one(DataTable)
+        table.clear(True)
+        for row in inventory.list_items():
+            table.add_row(row["id"], row["name"], row["status"], key=row["id"])
+
+    def show_details(self, item_id: str) -> None:
+        detail = self.query_one("#detail", Static)
+        item = inventory.get_item(item_id)
+        if item:
+            lines = [f"{k}: {v}" for k, v in item.items()]
+            detail.update("\n".join(lines))
+        else:
+            detail.update("Artikel nicht gefunden")
+
+    def action_switch_focus(self) -> None:
+        menu = self.query_one(ListView)
+        table = self.query_one(DataTable)
+        if self.focused is menu:
+            self.set_focus(table)
+        else:
+            self.set_focus(menu)
+
+    async def on_list_view_selected(self, event: ListView.Selected) -> None:
+        choice = event.item.query_one(Label).renderable
+        status = self.query_one("#status", Static)
+        if choice == "Quit":
+            self.exit()
+        elif choice == "Add":
+            data = await self.push_screen(ItemForm())
+            if data:
+                inventory.add_item(data)
+                self.refresh_table()
+                status.update("Artikel hinzugefügt")
+        elif choice == "Update":
+            table = self.query_one(DataTable)
+            if table.cursor_row is None:
+                status.update("Kein Artikel gewählt")
+                return
+            item_id = table.row_keys[table.cursor_row]
+            item = inventory.get_item(item_id)
+            data = await self.push_screen(ItemForm(item))
+            if data:
+                item_id = data.pop("id")
+                inventory.update_item_fields(item_id, data)
+                self.refresh_table()
+                status.update("Artikel aktualisiert")
+        elif choice == "Remove":
+            table = self.query_one(DataTable)
+            if table.cursor_row is None:
+                status.update("Kein Artikel gewählt")
+                return
+            item_id = table.row_keys[table.cursor_row]
+            inventory.remove_item_by_id(item_id)
+            self.refresh_table()
+            status.update("Artikel gelöscht")
+        elif choice == "Show":
+            table = self.query_one(DataTable)
+            if table.cursor_row is None:
+                status.update("Kein Artikel gewählt")
+                return
+            item_id = table.row_keys[table.cursor_row]
+            self.show_details(item_id)
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        self.show_details(event.row_key)
+
+
+def main() -> None:
+    app = InventoryApp()
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a simple Textual-based TUI with menu, details pane and item list
- expose non-interactive CRUD helpers in `modules.inventory`
- add `tui` subcommand in `main.py` to launch the new interface
- document TUI usage and dependency

## Testing
- `python -m py_compile main.py tui.py modules/inventory.py`
- `pip install textual` *(fails: Could not find a version that satisfies the requirement textual)*
- `python main.py -h` *(fails: ModuleNotFoundError: No module named 'textual')*

------
https://chatgpt.com/codex/tasks/task_e_68c1661608fc832bb6b279db80057c67