### PR TITLE
Fix TUI grid layout CSS

### DIFF
--- a/tui.py
+++ b/tui.py
@@ -62,10 +62,10 @@ class InventoryApp(App):
 
     CSS = """
     Screen { layout: grid; grid-size: 2 3; grid-rows: 1fr 3 6; grid-columns: 1fr 3fr; }
-    #menu { grid-row: 1; grid-column: 1; }
-    #detail { grid-row: 1; grid-column: 2; }
-    #search { grid-row: 2; grid-column-span: 2; }
-    #table { grid-row: 3; grid-column-span: 2; height: 8; }
+    #menu { }
+    #detail { }
+    #search { column-span: 2; }
+    #table { column-span: 2; height: 8; }
     #status { dock: bottom; height: 1; }
     """
 


### PR DESCRIPTION
## Summary
- remove invalid grid row/column declarations in `tui.py`
- rely on natural grid order and column-span to layout widgets

## Testing
- `/usr/local/bin/pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c179c0c5c8832ba99087df07cf884e