### PR TITLE
fix textual CSS grid properties for TUI

### DIFF
--- a/tui.py
+++ b/tui.py
@@ -62,10 +62,10 @@ class InventoryApp(App):
 
     CSS = """
     Screen { layout: grid; grid-size: 2 3; grid-rows: 1fr 3 6; grid-columns: 1fr 3fr; }
-    #menu { column: 1; row: 1; }
-    #detail { column: 2; row: 1; }
-    #search { row: 2; column-span: 2; }
-    #table { row: 3; column-span: 2; height: 8; }
+    #menu { grid-column: 1; grid-row: 1; }
+    #detail { grid-column: 2; grid-row: 1; }
+    #search { grid-row: 2; grid-column-span: 2; }
+    #table { grid-row: 3; grid-column-span: 2; height: 8; }
     #status { dock: bottom; height: 1; }
     """
 


### PR DESCRIPTION
## Summary
- update TUI CSS to use `grid-column`/`grid-row` properties
- adjust CSS spans to match current Textual syntax

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c17d9593e4832bb4a1b1b2b8ecb015